### PR TITLE
Update negotiator.go

### DIFF
--- a/negotiator.go
+++ b/negotiator.go
@@ -137,7 +137,7 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 
 		req.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
 
-		res, err = rt.RoundTrip(req)
+		return rt.RoundTrip(req)
 	}
 
 	return res, err


### PR DESCRIPTION
I've experienced the problem when non-nil err from rt.RoundTrip(req) didn't affect the result and this method returned pair nil, nil instead of nil, err.