### PR TITLE
Set workstation to empty string in authenticate_message.go

### DIFF
--- a/authenticate_message.go
+++ b/authenticate_message.go
@@ -42,7 +42,7 @@ func (m authenicateMessage) MarshalBinary() ([]byte, error) {
 	}
 
 	target, user := toUnicode(m.TargetName), toUnicode(m.UserName)
-	workstation := toUnicode("go-ntlmssp")
+	workstation := toUnicode("")
 
 	ptr := binary.Size(&authenticateMessageFields{})
 	f := authenticateMessageFields{


### PR DESCRIPTION
Setting the workstation to "go-ntlmssp" in this message can cause 401 errors if the user in use has limited login rights to servers. Leaving it blank at this stage when combined with setting it in the NewNegotiateMessage enables successful authentication.

This doesn't completely solve #26 but may be helpful. It may however solve #14 and #16 