### PR TITLE
Change of the negociator working, to handle several identical header

### DIFF
--- a/authheader.go
+++ b/authheader.go
@@ -7,13 +7,22 @@ import (
 
 type authheader []string
 
-func (h authheader) IsBasic() (bool, string) {
+func (h authheader) IsBasic() bool {
 	for _, s := range h {
 		if strings.HasPrefix(string(s), "Basic ") {
-			return true, s
+			return true
 		}
 	}
-	return false, ""
+	return false
+}
+
+func (h authheader) Basic() string {
+	for _, s := range h {
+		if strings.HasPrefix(string(s), "Basic ") {
+			return s
+		}
+	}
+	return ""
 }
 
 func (h authheader) IsNegotiate() bool {

--- a/authheader.go
+++ b/authheader.go
@@ -5,26 +5,46 @@ import (
 	"strings"
 )
 
-type authheader string
+type authheader []string
 
-func (h authheader) IsBasic() bool {
-	return strings.HasPrefix(string(h), "Basic ")
+func (h authheader) IsBasic() (bool, string) {
+	for _, s := range h {
+		if strings.HasPrefix(string(s), "Basic ") {
+			return true, s
+		}
+	}
+	return false, ""
 }
 
 func (h authheader) IsNegotiate() bool {
-	return strings.HasPrefix(string(h), "Negotiate")
+	for _, s := range h {
+		if strings.HasPrefix(string(s), "Negotiate") {
+			return true
+		}
+	}
+	return false
 }
 
 func (h authheader) IsNTLM() bool {
-	return strings.HasPrefix(string(h), "NTLM")
+	for _, s := range h {
+		if strings.HasPrefix(string(s), "NTLM") {
+			return true
+		}
+	}
+	return false
 }
 
 func (h authheader) GetData() ([]byte, error) {
-	p := strings.Split(string(h), " ")
-	if len(p) < 2 {
-		return nil, nil
+	for _, s := range h {
+		if strings.HasPrefix(string(s), "NTLM") || strings.HasPrefix(string(s), "Negotiate") || strings.HasPrefix(string(s), "Basic ") {
+			p := strings.Split(string(s), " ")
+			if len(p) < 2 {
+				return nil, nil
+			}
+			return base64.StdEncoding.DecodeString(string(p[1]))
+		}
 	}
-	return base64.StdEncoding.DecodeString(string(p[1]))
+	return nil, nil
 }
 
 func (h authheader) GetBasicCreds() (username, password string, err error) {

--- a/negotiator.go
+++ b/negotiator.go
@@ -36,7 +36,7 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 
 	// If it is not basic auth, just round trip the request as usual
 	reqauth := authheader(req.Header.Values("Authorization"))
-	isBasic, authHeader := reqauth.IsBasic()
+	isBasic, reqauthBasic := reqauth.IsBasic()
 	if !isBasic {
 		return rt.RoundTrip(req)
 	}

--- a/negotiator.go
+++ b/negotiator.go
@@ -33,9 +33,11 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
+
 	// If it is not basic auth, just round trip the request as usual
-	reqauth := authheader(req.Header.Get("Authorization"))
-	if !reqauth.IsBasic() {
+	reqauth := authheader(req.Header.Values("Authorization"))
+	isBasic, authHeader := reqauth.IsBasic()
+	if !isBasic {
 		return rt.RoundTrip(req)
 	}
 	// Save request body
@@ -59,11 +61,10 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 	if res.StatusCode != http.StatusUnauthorized {
 		return res, err
 	}
-
-	resauth := authheader(res.Header.Get("Www-Authenticate"))
+	resauth := authheader(res.Header.Values("Www-Authenticate"))
 	if !resauth.IsNegotiate() && !resauth.IsNTLM() {
 		// Unauthorized, Negotiate not requested, let's try with basic auth
-		req.Header.Set("Authorization", string(reqauth))
+		req.Header.Set("Authorization", string(authHeader))
 		io.Copy(ioutil.Discard, res.Body)
 		res.Body.Close()
 		req.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
@@ -75,7 +76,7 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 		if res.StatusCode != http.StatusUnauthorized {
 			return res, err
 		}
-		resauth = authheader(res.Header.Get("Www-Authenticate"))
+		resauth = authheader(res.Header.Values("Www-Authenticate"))
 	}
 
 	if resauth.IsNegotiate() || resauth.IsNTLM() {
@@ -112,7 +113,7 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 		}
 
 		// receive challenge?
-		resauth = authheader(res.Header.Get("Www-Authenticate"))
+		resauth = authheader(res.Header.Values("Www-Authenticate"))
 		challengeMessage, err := resauth.GetData()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Here a fix for the issue : https://github.com/Azure/go-ntlmssp/issues/21

Instead of managing a String, a string array is managed for headers that can have optionally several occurrences: WWW-Authenticate or Authorization.