### PR TITLE
Support for UPN

### DIFF
--- a/authenticate_message.go
+++ b/authenticate_message.go
@@ -82,7 +82,7 @@ func (m authenicateMessage) MarshalBinary() ([]byte, error) {
 
 //ProcessChallenge crafts an AUTHENTICATE message in response to the CHALLENGE message
 //that was received from the server
-func ProcessChallenge(challengeMessageData []byte, user, password string) ([]byte, error) {
+func ProcessChallenge(challengeMessageData []byte, user, password string, domainNeeded bool) ([]byte, error) {
 	if user == "" && password == "" {
 		return nil, errors.New("Anonymous authentication not supported")
 	}
@@ -97,6 +97,10 @@ func ProcessChallenge(challengeMessageData []byte, user, password string) ([]byt
 	}
 	if cm.NegotiateFlags.Has(negotiateFlagNTLMSSPNEGOTIATEKEYEXCH) {
 		return nil, errors.New("Key exchange requested but not supported (NTLMSSP_NEGOTIATE_KEY_EXCH)")
+	}
+	
+	if !domainNeeded {
+		cm.TargetName = ""
 	}
 
 	am := authenicateMessage{

--- a/negotiator.go
+++ b/negotiator.go
@@ -10,6 +10,7 @@ import (
 )
 
 // GetDomain : parse domain name from based on slashes in the input
+// Need to check for upn as well
 func GetDomain(user string) (string, string) {
 	domain := ""
 

--- a/negotiator.go
+++ b/negotiator.go
@@ -18,6 +18,7 @@ func GetDomain(user string) (string, string, bool) {
 	if strings.Contains(user, "\\") {
 		ucomponents := strings.SplitN(user, "\\", 2)
 		domain = ucomponents[0]
+		user = ucomponents[1]
 		domainNeeded = true
 	} else if strings.Contains(user, "@") {
 		domainNeeded = false

--- a/negotiator.go
+++ b/negotiator.go
@@ -100,7 +100,7 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 		u, domain, domainNeeded := GetDomain(u)
 
 		// send negotiate
-		authenticateMessage, err := ProcessChallenge(challengeMessage, u, p, domainNeeded)
+		negotiateMessage, err := NewNegotiateMessage(domain, "")
 		if err != nil {
 			return nil, err
 		}
@@ -131,7 +131,7 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 		res.Body.Close()
 
 		// send authenticate
-		authenticateMessage, err := ProcessChallenge(challengeMessage, u, p)
+		authenticateMessage, err := ProcessChallenge(challengeMessage, u, p, domainNeeded)
 		if err != nil {
 			return nil, err
 		}

--- a/negotiator.go
+++ b/negotiator.go
@@ -18,7 +18,7 @@ func GetDomain(user string) (string, string, bool) {
 	if strings.Contains(user, "\\") {
 		ucomponents := strings.SplitN(user, "\\", 2)
 		domain = ucomponents[0]
-		domainNeeded = false
+		domainNeeded = true
 	} else if strings.Contains(user, "@") {
 		domainNeeded = false
 	} else {

--- a/negotiator.go
+++ b/negotiator.go
@@ -11,15 +11,20 @@ import (
 
 // GetDomain : parse domain name from based on slashes in the input
 // Need to check for upn as well
-func GetDomain(user string) (string, string) {
+func GetDomain(user string) (string, string, bool) {
 	domain := ""
+	domainNeeded := false
 
 	if strings.Contains(user, "\\") {
 		ucomponents := strings.SplitN(user, "\\", 2)
 		domain = ucomponents[0]
-		user = ucomponents[1]
+		domainNeeded = false
+	} else if strings.Contains(user, "@") {
+		domainNeeded = false
+	} else {
+		domainNeeded = true
 	}
-	return user, domain
+	return user, domain, domainNeeded
 }
 
 //Negotiator is a http.Roundtripper decorator that automatically
@@ -92,10 +97,10 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 
 		// get domain from username
 		domain := ""
-		u, domain = GetDomain(u)
+		u, domain, domainNeeded := GetDomain(u)
 
 		// send negotiate
-		negotiateMessage, err := NewNegotiateMessage(domain, "")
+		authenticateMessage, err := ProcessChallenge(challengeMessage, u, p, domainNeeded)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Support for UPN
1. If the user name contains upn (user@domain.com) or SAM (domain\\sam), NOT prepending the domain name or netbios name while sending the response to challenge. (TYPE 3 token). 
2. If the username doesn't fall under category either UPN or SAM, prepending the domain name coming from (type 2 token) in the username while sending the response to server challenge. 

1. upn (user@domain.com) -- \user@domain.com
2. SAM (domain\user) -- domain\user
3. username (user) -- DOMAIN\user. 