### PR TITLE
Revert "Support for UPN"

### DIFF
--- a/authenticate_message.go
+++ b/authenticate_message.go
@@ -82,7 +82,7 @@ func (m authenicateMessage) MarshalBinary() ([]byte, error) {
 
 //ProcessChallenge crafts an AUTHENTICATE message in response to the CHALLENGE message
 //that was received from the server
-func ProcessChallenge(challengeMessageData []byte, user, password string, domainNeeded bool) ([]byte, error) {
+func ProcessChallenge(challengeMessageData []byte, user, password string) ([]byte, error) {
 	if user == "" && password == "" {
 		return nil, errors.New("Anonymous authentication not supported")
 	}
@@ -97,10 +97,6 @@ func ProcessChallenge(challengeMessageData []byte, user, password string, domain
 	}
 	if cm.NegotiateFlags.Has(negotiateFlagNTLMSSPNEGOTIATEKEYEXCH) {
 		return nil, errors.New("Key exchange requested but not supported (NTLMSSP_NEGOTIATE_KEY_EXCH)")
-	}
-	
-	if !domainNeeded {
-		cm.TargetName = ""
 	}
 
 	am := authenicateMessage{

--- a/negotiator.go
+++ b/negotiator.go
@@ -10,22 +10,15 @@ import (
 )
 
 // GetDomain : parse domain name from based on slashes in the input
-// Need to check for upn as well
-func GetDomain(user string) (string, string, bool) {
+func GetDomain(user string) (string, string) {
 	domain := ""
-	domainNeeded := false
 
 	if strings.Contains(user, "\\") {
 		ucomponents := strings.SplitN(user, "\\", 2)
 		domain = ucomponents[0]
 		user = ucomponents[1]
-		domainNeeded = true
-	} else if strings.Contains(user, "@") {
-		domainNeeded = false
-	} else {
-		domainNeeded = true
 	}
-	return user, domain, domainNeeded
+	return user, domain
 }
 
 //Negotiator is a http.Roundtripper decorator that automatically
@@ -98,7 +91,7 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 
 		// get domain from username
 		domain := ""
-		u, domain, domainNeeded := GetDomain(u)
+		u, domain = GetDomain(u)
 
 		// send negotiate
 		negotiateMessage, err := NewNegotiateMessage(domain, "")
@@ -132,7 +125,7 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 		res.Body.Close()
 
 		// send authenticate
-		authenticateMessage, err := ProcessChallenge(challengeMessage, u, p, domainNeeded)
+		authenticateMessage, err := ProcessChallenge(challengeMessage, u, p)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Revert Azure/go-ntlmssp#32 as it breaks backwards compatibility.

See ticket #33 

These changes should be reviewed to see if they can be provided in a non-breaking way