### PR TITLE
Use domain from username, not server/target when authenticating

### DIFF
--- a/authenticate_message.go
+++ b/authenticate_message.go
@@ -82,7 +82,7 @@ func (m authenicateMessage) MarshalBinary() ([]byte, error) {
 
 //ProcessChallenge crafts an AUTHENTICATE message in response to the CHALLENGE message
 //that was received from the server
-func ProcessChallenge(challengeMessageData []byte, user, password string, domainNeeded bool) ([]byte, error) {
+func ProcessChallenge(challengeMessageData []byte, user, password string, domainNeeded bool, domain string) ([]byte, error) {
 	if user == "" && password == "" {
 		return nil, errors.New("Anonymous authentication not supported")
 	}
@@ -101,6 +101,9 @@ func ProcessChallenge(challengeMessageData []byte, user, password string, domain
 	
 	if !domainNeeded {
 		cm.TargetName = ""
+	} else {
+		// use user's domain for authentication, not server domain
+		cm.TargetName = domain
 	}
 
 	am := authenicateMessage{

--- a/negotiator.go
+++ b/negotiator.go
@@ -132,7 +132,7 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 		res.Body.Close()
 
 		// send authenticate
-		authenticateMessage, err := ProcessChallenge(challengeMessage, u, p, domainNeeded)
+		authenticateMessage, err := ProcessChallenge(challengeMessage, u, p, domainNeeded, domain)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This fixes authentication problems if user and server domain are different.

Without this change, the server's domain is used to construct "authenticateMessage" and "ntlmv2Hash". This will not work in a multi-domain setup.