### PR TITLE
Fix UPN format parsing in splitNameForAuth

### DIFF
--- a/authenticate_message.go
+++ b/authenticate_message.go
@@ -90,7 +90,9 @@ func splitNameForAuth(username string) (user, domain string) {
 		domain = ucomponents[0]
 		user = ucomponents[1]
 	} else if strings.Contains(username, "@") {
-		user = username
+		ucomponents := strings.SplitN(username, "@", 2)
+		user = ucomponents[0]
+		domain = ucomponents[1]
 	} else {
 		user = username
 	}


### PR DESCRIPTION
Correctly split user@domain format into separate user and domain components instead of assigning the entire string to user field.

Found by PostgresPro.
Fixes: 8998db2 ("Support user accounts not living in server's domain (#65)")