### PR TITLE
Add options-based negotiate message construction

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,11 @@ jobs:
           Write-Host "Setting up NTLM test environment using setup script..."
 
           # Generate a random password for this test run
-          $randomPassword = -join ((65..90) + (97..122) + (48..57) + @(33,35,36,37,38,42,43,45,61,63,64) | Get-Random -Count 16 | % {[char]$_})
+          $upper = 65..90 | Get-Random -Count 4 | ForEach-Object { [char]$_ }
+          $lower = 97..122 | Get-Random -Count 4 | ForEach-Object { [char]$_ }
+          $digits = 48..57 | Get-Random -Count 4 | ForEach-Object { [char]$_ }
+          $symbols = @(33,35,36,37,38,42,43,45,61,63,64) | Get-Random -Count 4 | ForEach-Object { [char]$_ }
+          $randomPassword = -join (($upper + $lower + $digits + $symbols) | Get-Random -Count 16)
           Write-Host "Generated random test password"
 
           # Run the setup script with random password

--- a/negotiate_message.go
+++ b/negotiate_message.go
@@ -30,6 +30,20 @@ var defaultFlags = negotiateFlagNTLMSSPNEGOTIATETARGETINFO |
 	negotiateFlagNTLMSSPNEGOTIATENTLM |
 	negotiateFlagNTLMSSPNEGOTIATEALWAYSSIGN
 
+// NegotiateMessageOptions contains optional parameters for the NEGOTIATE message.
+// The zero value is valid and sends neither client domain nor workstation name.
+type NegotiateMessageOptions struct {
+	// Domain is the domain of the client machine.
+	// Per the NTLM spec, it may be empty. When empty, no domain bytes are sent and
+	// NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED is left unset.
+	Domain string
+
+	// Workstation is the name of the client machine.
+	// Per the NTLM spec, it may be empty. When empty, no workstation bytes are sent and
+	// NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED is left unset.
+	Workstation string
+}
+
 // NewNegotiateMessage creates a new NEGOTIATE message with the flags that this package supports.
 // Note that domain and workstation refer to the client machine, not the user that is authenticating.
 // It is recommended to leave them empty unless you know which are their correct values.
@@ -37,8 +51,21 @@ var defaultFlags = negotiateFlagNTLMSSPNEGOTIATETARGETINFO |
 // The server may ignore these values, or may use them to infer that the client if running on the
 // same machine.
 func NewNegotiateMessage(domain, workstation string) ([]byte, error) {
+	return NewNegotiateMessageWithOptions(NegotiateMessageOptions{
+		Domain:      domain,
+		Workstation: workstation,
+	})
+}
+
+// NewNegotiateMessageWithOptions creates a new NEGOTIATE message from the supplied options.
+// Use this function when setting optional NEGOTIATE message fields. To preserve compatibility
+// with existing callers, [NewNegotiateMessage] remains available for passing only the client
+// domain and workstation values.
+func NewNegotiateMessageWithOptions(options NegotiateMessageOptions) ([]byte, error) {
 	payloadOffset := expMsgBodyLen
 	flags := defaultFlags
+	domain := options.Domain
+	workstation := options.Workstation
 
 	if domain != "" {
 		flags |= negotiateFlagNTLMSSPNEGOTIATEOEMDOMAINSUPPLIED

--- a/negotiator.go
+++ b/negotiator.go
@@ -287,7 +287,10 @@ func clientHandshake(rt http.RoundTripper, req *http.Request, schema string, dom
 	if rewindBody(req) != nil {
 		return nil
 	}
-	auth, err := NewNegotiateMessage(domain, workstation)
+	auth, err := NewNegotiateMessageWithOptions(NegotiateMessageOptions{
+		Domain:      domain,
+		Workstation: workstation,
+	})
 	if err != nil {
 		return nil
 	}

--- a/nlmp_test.go
+++ b/nlmp_test.go
@@ -66,7 +66,10 @@ func TestUsernameDomainWorkstation(t *testing.T) {
 			t.Fatalf("domain not correct, expected %v got %v", tdomain, table.xd)
 		}
 
-		tb, err := NewNegotiateMessage(tdomain, table.w)
+		tb, err := NewNegotiateMessageWithOptions(NegotiateMessageOptions{
+			Domain:      tdomain,
+			Workstation: table.w,
+		})
 		if err != nil {
 			t.Fatalf("error creating new negotiate message with domain '%v' and workstation '%v'", tdomain, table.w)
 		}

--- a/scripts/setup-local-e2e.ps1
+++ b/scripts/setup-local-e2e.ps1
@@ -8,9 +8,18 @@ param(
     [string]$TestPassword = ""
 )
 
+function New-TestPassword {
+    $upper = 65..90 | Get-Random -Count 4 | ForEach-Object { [char]$_ }
+    $lower = 97..122 | Get-Random -Count 4 | ForEach-Object { [char]$_ }
+    $digits = 48..57 | Get-Random -Count 4 | ForEach-Object { [char]$_ }
+    $symbols = @(33,35,36,37,38,42,43,45,61,63,64) | Get-Random -Count 4 | ForEach-Object { [char]$_ }
+
+    return -join (($upper + $lower + $digits + $symbols) | Get-Random -Count 16)
+}
+
 # Generate a random password if none provided
 if ([string]::IsNullOrEmpty($TestPassword)) {
-    $TestPassword = -join ((65..90) + (97..122) + (48..57) + @(33,35,36,37,38,42,43,45,61,63,64) | Get-Random -Count 16 | % {[char]$_})
+    $TestPassword = New-TestPassword
     Write-Host "Generated random test password for security" -ForegroundColor Cyan
 }
 


### PR DESCRIPTION
## Summary
- Add `NewNegotiateMessageWithOptions` for building NEGOTIATE messages from an options value.
- Route internal NEGOTIATE message creation through the options-based constructor.
- Keep `NewNegotiateMessage` as the compatibility wrapper for existing domain/workstation callers.
- Make E2E test password generation satisfy Windows password complexity requirements reliably.

## Why
This gives callers a clear place to customize NEGOTIATE message inputs without changing the existing constructor. Today it carries the optional client domain and workstation values; over time it can grow with additional NEGOTIATE message settings in a compatible way, see for example #82.

The options documentation also calls out the spec behavior for empty domain and workstation values: no bytes are sent for that field, and the corresponding NTLMSSP_NEGOTIATE_OEM_*_SUPPLIED flag remains unset.

The E2E workflow failure came from randomly generating a password that did not meet the Windows runner's complexity policy. The generator now always includes uppercase, lowercase, digit, and symbol characters.